### PR TITLE
Option to set SourceCategory from AWS log group & stream.

### DIFF
--- a/cloudwatchlogs/README.md
+++ b/cloudwatchlogs/README.md
@@ -38,6 +38,7 @@ The following AWS Lambda environment variables are supported
 * `SOURCE_CATEGORY_OVERRIDE` (OPTIONAL) - Override _sourceCategory metadata field within SumoLogic. If `none` will not be overridden
 * `SOURCE_HOST_OVERRIDE` (OPTIONAL) - Override _sourceHost metadata field within SumoLogic. If `none` will not be overridden
 * `SOURCE_NAME_OVERRIDE` (OPTIONAL) - Override _sourceName metadata field within SumoLogic. If `none` will not be overridden
+* `SET_SOURCE_CATEGORY_FROM_AWS` (Optional) - When set to true the source category will be set to `[AWS Log Group]/[AWS Log Stream]` by default.
 
 # Dynamic Metadata Fields
 

--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -14,6 +14,8 @@ var SumoURL = process.env.SUMO_ENDPOINT;
 var sourceCategoryOverride = process.env.SOURCE_CATEGORY_OVERRIDE || 'none';  // If none sourceCategoryOverride will not be overridden
 var sourceHostOverride = process.env.SOURCE_HOST_OVERRIDE || 'none';          // If none sourceHostOverride will not be set to the name of the logGroup
 var sourceNameOverride = process.env.SOURCE_NAME_OVERRIDE || 'none';          // If none sourceNameOverride will not be set to the name of the logStream
+var setSourceCategoryFromAws = process.env.SET_SOURCE_CATEGORY_FROM_AWS || 'false'; // When set to 'true' and when category is unset by the app or SOURCE_CATEGORY_OVERRIDE
+                                                                                    //  the source category will be set to default values from AWS Log Group and Log Stream
 
 // CloudWatch logs encoding
 var encoding = process.env.ENCODING || 'utf-8';  // default is utf-8
@@ -70,8 +72,14 @@ function sumoMetaKey(awslogsData, message) {
         }
         delete message._sumo_metadata;
     }
+
+    // If sourceCategory is unset default to AWS logs identifiers
+    if (sourceCategory === '' && setSourceCategoryFromAws == 'true') {
+	sourceCategory = awslogsData.logGroup + "/" + awslogsData.logStream;
+    }
+
     return sourceName + ':' + sourceCategory + ':' + sourceHost;
-    
+
 }
 
 function postToSumo(context, messages) {


### PR DESCRIPTION
This PR adds support for setting source category from the AWS log fields.  This feature is off by default for backwards compatibility, and only applies when the source category is unset by an override or the application metadata.  When enabled this feature sets the default category to `[AWS log group]/[AWS log stream]`.  This is believed to be a sane default, it groups the categories logically based on information already present in the AWS stream.

For example, when using AWS ECS awslogs driver the category is `[AWS Log Group]/[AWS Log Prefix]/[ECS container name]/[ECS Task ID]`[¹](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html)